### PR TITLE
修复密码修改报错的问题

### DIFF
--- a/jiacrontab_admin/user.go
+++ b/jiacrontab_admin/user.go
@@ -292,7 +292,7 @@ func EditUser(ctx *myctx) {
 
 	// change password
 	if reqBody.OldPwd != "" && reqBody.Passwd != "" {
-		if !user.Verify(reqBody.Username, reqBody.OldPwd) {
+		if !user.VerifyByUserId(reqBody.UserID, reqBody.OldPwd) {
 			ctx.respParamError(errors.New("密码错误"))
 			return
 		}

--- a/models/user.go
+++ b/models/user.go
@@ -53,6 +53,23 @@ func (u *User) Verify(username, passwd string) bool {
 	return false
 }
 
+// Verify 验证用户
+func (u *User) VerifyByUserId(id uint, passwd string) bool {
+	ret := DB().Take(u, "id=?", id)
+
+	if ret.Error != nil {
+		log.Error("user.Verify:", ret.Error)
+		return false
+	}
+
+	bts := md5.Sum([]byte(fmt.Sprint(passwd, u.Salt)))
+	if fmt.Sprintf("%x", bts) == u.Passwd {
+		return true
+	}
+
+	return false
+}
+
 func (u *User) setPasswd() {
 	if u.Passwd == "" {
 		return


### PR DESCRIPTION
前端修改用户密码的时候，提交了 userid 和 password，后端是用 usernname 和 password 校验的，导致修改密码时提示当前用户找不到。